### PR TITLE
Don't start thread in the function passed to swap!

### DIFF
--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -296,11 +296,11 @@
   Returns a context which can be used to stop superlifter, enqueue muses and trigger fetches.
   "
   [opts]
-  (let [context (-> (merge (default-opts) opts)
-                    (update-in [:buckets default-bucket-id] #(or % {}))
-                    (update :buckets atom)
-                    (start-buckets!))]
-    (start-trigger-watchers! context)))
+  (-> (merge (default-opts) opts)
+      (update-in [:buckets default-bucket-id] #(or % {}))
+      (update :buckets atom)
+      (start-buckets!)
+      (start-trigger-watchers!)))
 
 (defn stop!
   "Stops superlifter"

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -132,14 +132,14 @@
 
 (defmethod start-trigger! :interval [_ bucket-id opts]
   (let [start-fn #?(:clj (fn [context]
-                           (swap! start-count inc)
+                           (swap! start-count inc)  ;; TODO: 테스트 후에 삭제 예정
                            (let [watcher (future (loop []
                                                    (Thread/sleep (:interval opts))
                                                    (fetch-all-handling-errors! context bucket-id)
                                                    (recur)))]
                              ;; return a function to stop the watcher
                              (fn []
-                               (swap! stop-count inc)  ;; to check the thread stop count
+                               (swap! stop-count inc)  ;; TODO: 테스트 후에 삭제 예정
                                (future-cancel watcher))))
                     :cljs (fn [context]
                             (let [watcher
@@ -169,7 +169,7 @@
   (let [interval (:interval opts)
         last-updated (atom nil)
         start-fn #?(:clj (fn [context]
-                           (swap! start-count inc)
+                           (swap! start-count inc)  ;; TODO: 테스트 후에 삭제 예정
                            (let [watcher (future (loop []
                                                    (let [lu @last-updated]
                                                      (cond
@@ -188,7 +188,7 @@
                                                            (recur))))))]
                              ;; return a function to stop the watcher
                              (fn []
-                               (swap! stop-count inc)
+                               (swap! stop-count inc)  ;; TODO: 테스트 후에 삭제 예정
                                (future-cancel watcher)
                                (reset! last-updated :exit))))
                     :cljs (fn [context]

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -54,13 +54,9 @@
                (when cache
                  (urania-> cache new-cache-value))
                (doall (map prom/resolve! promises result))))
-               ;(run! (fn [[p result]] (prom/resolve! p result))
-               ;      (zipmap promises result))))
             (prom/catch
              (fn [ex]
                (doall (map prom/reject! promises (repeat ex)))))))
-               ;(run! (fn [p] (prom/reject! p ex))
-               ;      promises)))))
       (do (log :debug "Nothing ready to fetch for" bucket-id)
           (prom/resolved nil)))))
 

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -133,7 +133,6 @@
                                                    (Thread/sleep (:interval opts))
                                                    (fetch-all-handling-errors! context bucket-id)
                                                    (recur)))]
-
                              ;; return a function to stop the watcher
                              #(future-cancel watcher)))
                     :cljs (fn [context]
@@ -243,8 +242,8 @@
   {:urania-opts {:cache (atom {})}})
 
 (defn start-trigger-watchers!
-  "Calls start-fn for each trigger, traversing all triggers in the buckets atom
-  Returns context map with stop-fns associated, which is a map stores functions to stop watcher threads for each trigger."
+  "Calls start-fn for each trigger if exists, traversing all triggers in the buckets atom.
+  Returns new context with :stop-fns associated, which is a map storing functions to stop watcher threads of those triggers."
   [context]
   (let [stop-fns (->> (for [[bucket-id bucket] @(:buckets context)]
                         [bucket-id (->> (for [[trigger-kind trigger] (:triggers bucket)


### PR DESCRIPTION
(with @SongKJ00)

### 문제
`start!`함수 내부에서 `swap!`을 호출할 때, 그에 넘겨주는 함수(아래의 익명 함수)는 side effect로 스레드를 새로 생성하는 동작을 합니다.

https://github.com/green-labs/superlifter/blob/e0df5b36b496c485c75f38052a71b18f02772cc0/src/superlifter/core.cljc#L203-L206

이 익명 함수를 타고 들어가면, `start-buckets! -> start-bucket! -> start-triggers! -> start-trigger!` 순으로 호출이 되고, `start-trigger!`의 `:interval`과 `:debounced` method가 future를 부르면서 새 스레드를 생성합니다.

https://github.com/green-labs/superlifter/blob/e0df5b36b496c485c75f38052a71b18f02772cc0/src/superlifter/core.cljc#L130-L135

https://github.com/green-labs/superlifter/blob/e0df5b36b496c485c75f38052a71b18f02772cc0/src/superlifter/core.cljc#L158-L165


하지만 swap!에 전달되는 함수는 여러 번 실행될 수 있다는 가정이 있고, [공식 문서](https://clojuredocs.org/clojure.core/swap!)에서도 side effect가 없는 함수를 전달하라고 설명되어 있습니다. 바로 이 부분이 스레드 누수를 일으키고 있었습니다.

> Atomically swaps the value of atom to be: (apply f current-value-of-atom args). **Note that f may be called multiple times, and thus should be free of side effects.** Returns the value that was swapped in.

(해당 atom에 경쟁적으로 access할 때에만 swap!에 전달되는 함수가 여러 번 실행될 수 있기 때문에 이 코드에서 어떻게 그런 일이 생기는지 궁금하실 수 있는데, 그 원인에 대해서는 댓글에서 자세히 설명하겠습니다)


### 해결 방법
- 그 side effect를 제거하기 위해, 스레드를 새로 생성할 수 있는 함수(`start-fn`)만 만들어서 반환하도록 합니다. 
- 또한 그 `start-fn` 들을 swap! 이후에 불러주도록 하여 스레드 생성 시점을 조절합니다.