### PR TITLE
use vthread 2

### DIFF
--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -124,12 +124,15 @@
 
 (defmethod start-trigger! :interval [_ bucket-id opts]
   (let [start-fn #?(:clj (fn [context]
-                           (let [watcher (future (loop []
-                                                   (Thread/sleep (:interval opts))
-                                                   (fetch-all-handling-errors! context bucket-id)
-                                                   (recur)))]
+                           (let [continue? (atom true)
+                                 _watcher (prom/create (fn [resolve _reject]
+                                                         (while @continue?
+                                                           (Thread/sleep (:inverval opts))
+                                                           (fetch-all-handling-errors! context bucket-id))
+                                                         (resolve true))
+                                                       :vthread)]
                              ;; return a function to stop the watcher
-                             #(future-cancel watcher)))
+                             #(reset! continue? false)))
                     :cljs (fn [context]
                             (let [watcher
                                   (js/setInterval #(fetch-all-handling-errors! context bucket-id)


### PR DESCRIPTION
interval 버킷에서, future가 아닌 JDK 21에 새로 들어온 가상스레드를 사용하도록 변경하는 PR입니다.

https://github.com/green-labs/superlifter/pull/3 PR은 conflict 해결이 더 오래 걸릴 것 같아서, 그냥 최신 master 기준에서 새로 수정하였습니다.