### PR TITLE
remove medley deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,6 @@
  :deps  {funcool/urania            {:git/url "https://github.com/funcool/urania.git"
                                     :git/sha "4043efef7e7e280a40417f38250168e99a3b5fec"}
          funcool/promesa           {:mvn/version "10.0.594"}
-         dev.weavejester/medley    {:mvn/version "1.8.1"}
          org.clojure/tools.logging {:mvn/version "0.6.0"}}
 
  :mvn/repos

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps  {funcool/urania            {:git/url "https://github.com/funcool/urania.git"
                                     :git/sha "4043efef7e7e280a40417f38250168e99a3b5fec"}
          funcool/promesa           {:mvn/version "10.0.594"}
-         medley/medley             {:mvn/version "1.4.0"}
+         dev.weavejester/medley    {:mvn/version "1.8.1"}
          org.clojure/tools.logging {:mvn/version "0.6.0"}}
 
  :mvn/repos

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -200,8 +200,6 @@
      :cljs (satisfies? cljs.core/IEditableCollection coll)))
 
 (defn- reduce-map
-  "Maps a function over the key/value pairs of an associative collection, using
-   the return of the function as the new value."
   [f coll]
   (let [coll' (if (record? coll) (into {} coll) coll)]
     (if (editable? coll')

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -199,15 +199,22 @@
   #?(:clj  (instance? clojure.lang.IEditableCollection coll)
      :cljs (satisfies? cljs.core/IEditableCollection coll)))
 
-(defn- map-kv-vals
-  "Copy of medley.core/map-kv-vals,
-   Maps a function over the key/value pairs of an associative collection, using
+(defn- reduce-map
+  "Maps a function over the key/value pairs of an associative collection, using
    the return of the function as the new value."
   [f coll]
   (let [coll' (if (record? coll) (into {} coll) coll)]
     (if (editable? coll')
       (persistent! (reduce-kv (f assoc!) (transient (empty coll')) coll'))
       (reduce-kv (f assoc) (empty coll') coll'))))
+
+(defn map-kv-vals
+  "Copy of medley.core/map-kv-vals,
+   Maps a function over the key/value pairs of an associative collection, using
+  the return of the function as the new value."
+  {:added "1.2.0"}
+  [f coll]
+  (reduce-map (fn [xf] (fn [m k v] (xf m k (f k v)))) coll))
 
 (defn- start-triggers! [bucket-id bucket-opts]
   (update bucket-opts :triggers


### PR DESCRIPTION
medley/medley가 dev.weavejester/medley로 groupId 변경이 있었고, 변경된 메들리 아티팩트(dev.weavejester)와 superlifter(medley)를 같이 사용하는 경우 의존성 트리에 conflict가 생길 수 있습니다.

참고: 
https://github.com/clojars/clojars-web/discussions/870

> I'm not certain what the best solution is to this, now that I have released libraries under the new group IDs. I can add a dependency from com.example/example to example/example, or vice versa, but either way the dependency depth is increased by one, and this affects which dependency gets priority if there are any conflicts in the dependency tree.

이를 해결하기 위해 최신 버전으로 업데이트합니다.