### PR TITLE
avoid reflection on thread sleep

### DIFF
--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -124,7 +124,7 @@
 (defmethod start-trigger! :interval [_ bucket-id opts]
   (let [start-fn #?(:clj (fn [context]
                            (let [watcher (future (loop []
-                                                   (Thread/sleep (:interval opts))
+                                                   (Thread/sleep ^java.lang.Long (:interval opts))
                                                    (fetch-all-handling-errors! context bucket-id)
                                                    (recur)))]
                              ;; return a function to stop the watcher
@@ -160,7 +160,7 @@
                            (let [watcher (future (loop []
                                                    (let [lu @last-updated]
                                                      (cond
-                                                       (nil? lu) (do (Thread/sleep interval)
+                                                       (nil? lu) (do (Thread/sleep ^java.lang.Long interval)
                                                                      (recur))
 
                                                        (= :exit lu) nil
@@ -171,7 +171,7 @@
                                                            (recur))
 
                                                        :else
-                                                       (do (Thread/sleep (- interval (- (System/currentTimeMillis) lu)))
+                                                       (do (Thread/sleep ^java.lang.Long (- interval (- (System/currentTimeMillis) lu)))
                                                            (recur))))))]
 
                              ;; return a function to stop the watcher

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -7,6 +7,8 @@
 
 #?(:cljs (def Throwable js/Error))
 
+(set! *warn-on-reflection* true)
+
 (defprotocol Cache
   (->urania [this])
   (urania-> [this new-value]))
@@ -124,7 +126,7 @@
 (defmethod start-trigger! :interval [_ bucket-id opts]
   (let [start-fn #?(:clj (fn [context]
                            (let [watcher (future (loop []
-                                                   (Thread/sleep ^java.lang.Long (:interval opts))
+                                                   (Thread/sleep ^long (:interval opts))
                                                    (fetch-all-handling-errors! context bucket-id)
                                                    (recur)))]
                              ;; return a function to stop the watcher
@@ -160,7 +162,7 @@
                            (let [watcher (future (loop []
                                                    (let [lu @last-updated]
                                                      (cond
-                                                       (nil? lu) (do (Thread/sleep ^java.lang.Long interval)
+                                                       (nil? lu) (do (Thread/sleep ^long interval)
                                                                      (recur))
 
                                                        (= :exit lu) nil
@@ -171,7 +173,7 @@
                                                            (recur))
 
                                                        :else
-                                                       (do (Thread/sleep ^java.lang.Long (- interval (- (System/currentTimeMillis) lu)))
+                                                       (do (Thread/sleep ^long (- interval (- (System/currentTimeMillis) lu)))
                                                            (recur))))))]
 
                              ;; return a function to stop the watcher


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7e96e8de-72b6-4c85-b2a1-9f39ad188991)

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#sleep(long)

java 19부터 java thread sleep에 Duration 타입의 오버로딩이 추가되어, 
java 19 이상을 사용하는 경우 runtime에 reflection과 이로 인한 성능 저하가 발생하게 됩니다.
이 문제를 개선하기 위해 type hint를 추가하여 reflection이 발생하지 않도록 수정합니다.
