### PR TITLE
bump urania

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps  {funcool/urania            {:git/url "https://github.com/funcool/urania.git"
-                                    :git/sha "4043efef7e7e280a40417f38250168e99a3b5fec"}
+                                    :git/sha "8ef21474db8ecf97c29c668275dd104b30128cde"}
          funcool/promesa           {:mvn/version "10.0.594"}
          org.clojure/tools.logging {:mvn/version "0.6.0"}}
 


### PR DESCRIPTION
https://github.com/funcool/urania/pull/22
urania의 Executor 실행 시 reflection이 발생하고 있었는데 이를 개선한 버전으로 업데이트해봅니다.